### PR TITLE
Use any field from entity as identifier

### DIFF
--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -263,7 +263,7 @@ class UploadBehavior extends Behavior
     protected function _buildIdentifiersArray(Array $entityArray, $useFieldIdentifiers = true)
     {
         $identifiers = [
-            ':id' => isset($entityArray['id']) ? $entityArray['id'] : '',
+            ':id' => isset($entityArray['id']) ? $entityArray['id'] : 'id',
             ':md5' => md5(rand() . uniqid() . time()),
             ':y' => date('Y'),
             ':m' => date('m'),


### PR DESCRIPTION
Allows for use of any field in the entity to be used as an identifier. Also updated readme. Identifier building was moved to its own function and various functions were added to accommodate these changes. See the updated readme and documentation within UploadBehavior.php for more information. Closes #11 by making all fields available.