### PR TITLE
Added array check to skip hasMany and belongsToMany associations

### DIFF
--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -303,8 +303,11 @@ class UploadBehavior extends Behavior
     {
         if(is_array($value)) {
             strcmp($prefix, '') ? $prefix = $prefix . '.' . $key : $prefix = $key;
-            foreach($value as $subKey => $subValue) {
-                $fieldIdentifiers = $this->_addIdentifiers($subKey, $subValue, $prefix, $fieldIdentifiers);
+            $arrayKeys = array_keys($value);
+            if(array_keys($arrayKeys) !== $arrayKeys) {
+                foreach($value as $subKey => $subValue) {
+                    $fieldIdentifiers = $this->_addIdentifiers($subKey, $subValue, $prefix, $fieldIdentifiers);
+                }
             }
         } else {
             strcmp($prefix, '') ? $field = ':' . $prefix . '.' . $key : $field = ':' . $key;


### PR DESCRIPTION
Added check which checks if array is sequential or associative. If it is
sequential, the data represents that from a hasMany or belongsToMany
association and is skipped accordingly.